### PR TITLE
android atom writer optimization

### DIFF
--- a/chemistry-opencmis-android/chemistry-opencmis-android-client/src/main/java/org/apache/chemistry/opencmis/client/bindings/spi/atompub/AtomEntryWriter.java
+++ b/chemistry-opencmis-android/chemistry-opencmis-android-client/src/main/java/org/apache/chemistry/opencmis/client/bindings/spi/atompub/AtomEntryWriter.java
@@ -236,20 +236,11 @@ public class AtomEntryWriter {
     private void writeContent(XmlSerializer writer) throws IOException {
         @SuppressWarnings("resource")
         Base64.InputStream b64stream = new Base64.InputStream(stream, Base64.ENCODE);
+        byte[] buffer = new byte[BUFFER_SIZE];
+        int numBytes;
 
-        char[] buffer = new char[BUFFER_SIZE];
-        int pos = 0;
-        int b;
-
-        while ((b = b64stream.read()) > -1) {
-            buffer[pos++] = (char) (b & 0xFF);
-            if (pos == buffer.length) {
-                writer.text(buffer, 0, buffer.length);
-                pos = 0;
-            }
-        }
-        if (pos > 0) {
-            writer.text(buffer, 0, pos);
+        while ((numBytes = b64stream.read(buffer, 0, BUFFER_SIZE)) >= 0) {
+            writer.text(new String(buffer, 0, numBytes, "ISO-8859-1"));
         }
     }
 


### PR DESCRIPTION
This is related to https://issues.apache.org/jira/browse/CMIS-444. For files grated then 4MB `AtomEntryWriter` performance still unsatisfactory on Android platform. Writing by one byte even to buffered stream is too slow. This patch makes this class to write whole portion of base64 encoded content.
